### PR TITLE
Serialze integration test runs

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -46,6 +46,14 @@ jobs:
       run: |
         echo -n "$CONFIG_FILE" > $INI_FILE && [ -s $INI_FILE ] || (>&2 echo no secrets provided; exit 1)
 
+    - name: Ensure no other integration test is currently running
+      uses: softprops/turnstyle@v0.1.3
+      timeout-minutes: 60
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        same-branch-only: false
+
     - name: Run the tests
       run: >-
         ansible-test


### PR DESCRIPTION
If multiple instances of the integration test workflow run in parallel
the CI account may run into Quota limits. Unfortunately Github Actions
don't (yet) have a mechanism to ensure only one instance of a workflow
runs in parallel. To serialize this uses "softprops/turnstyle" action
from the Github Marketplace which queries the Github API for running
workflows.