### PR TITLE
Allow identical name per zone

### DIFF
--- a/changelogs/fragments/allow-similar-name-per-zone.yml
+++ b/changelogs/fragments/allow-similar-name-per-zone.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Implement distinquish per zone to allow identical naming of the same resource type per zone (https://github.com/cloudscale-ch/ansible-collection-cloudscale/pull/46).

--- a/changelogs/fragments/allow-similar-name-per-zone.yml
+++ b/changelogs/fragments/allow-similar-name-per-zone.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Implement distinquish per zone to allow identical naming of the same resource type per zone (https://github.com/cloudscale-ch/ansible-collection-cloudscale/pull/46).
+  - Implemented identical naming support of the same resource type per zone (https://github.com/cloudscale-ch/ansible-collection-cloudscale/pull/46).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -203,8 +203,14 @@ class AnsibleCloudscaleBase(AnsibleCloudscaleApi):
 
                 # Skip resource if constraints is not given e.g. in case of floating_ip the ip_version differs
                 for constraint_key in self.query_constraint_keys:
-                    if resource[constraint_key] != self._module.params[constraint_key]:
-                        break
+                    if self._module.params[constraint_key] is not None:
+                        if constraint_key == 'zone':
+                            resource_value = resource['zone']['slug']
+                        else:
+                            resource_value = resource[constraint_key]
+
+                        if resource_value != self._module.params[constraint_key]:
+                            break
                 else:
                     if resource[self.resource_key_name] == name:
                         matching.append(resource)

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -182,6 +182,10 @@ def main():
         ],
     )
 
+    cloudscale_network.query_constraint_keys = [
+        'zone',
+    ]
+
     if module.params['state'] == 'absent':
         result = cloudscale_network.absent()
     else:

--- a/plugins/modules/server_group.py
+++ b/plugins/modules/server_group.py
@@ -156,6 +156,9 @@ def main():
             'tags',
         ],
     )
+    cloudscale_server_group.query_constraint_keys = [
+        'zone',
+    ]
 
     if module.params['state'] == 'absent':
         result = cloudscale_server_group.absent()

--- a/tests/integration/targets/common/defaults/main.yml
+++ b/tests/integration/targets/common/defaults/main.yml
@@ -14,6 +14,7 @@ cloudscale_test_ssh_key: |
 
 # The zone to use to test servers
 cloudscale_test_zone: 'lpg1'
+cloudscale_test_alt_zone: 'rma1'
 
 # The region to use to request floating IPs
 cloudscale_test_region: 'lpg'

--- a/tests/integration/targets/server_group/tasks/tests.yml
+++ b/tests/integration/targets/server_group/tasks/tests.yml
@@ -2,6 +2,7 @@
 - name: Create server group in check mode
   cloudscale_ch.cloud.server_group:
     name: '{{ cloudscale_resource_prefix }}-grp'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -56,6 +57,26 @@
       - grp.name == '{{ cloudscale_resource_prefix }}-grp'
       - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.uuid == server_group_uuid
+      - grp.tags.project == 'ansible-test'
+      - grp.tags.stage == 'production'
+      - grp.tags.sla == '24-7'
+
+- name: Create server group with same name in alt zone
+  cloudscale_ch.cloud.server_group:
+    name: '{{ cloudscale_resource_prefix }}-grp'
+    zone: '{{ cloudscale_test_alt_zone }}'
+    tags:
+      project: ansible-test
+      stage: production
+      sla: 24-7
+  register: grp
+- name: 'VERIFY:Create server group with same name in alt zone'
+  assert:
+    that:
+      - grp is changed
+      - grp.name == '{{ cloudscale_resource_prefix }}-grp'
+      - grp.zone.slug == '{{ cloudscale_test_alt_zone }}'
+      - grp.uuid != server_group_uuid
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'production'
       - grp.tags.sla == '24-7'


### PR DESCRIPTION
Currently we do not distinguish per zone to find the resource and that is why it is not possible to have similar names in the second zone. e.g. server-group with name `web` in rma1 and lpg1.

This patch removes this limitation by adding `zone` as a constraint: