### PR TITLE
Cleanup networks after server integration tests

### DIFF
--- a/tests/integration/targets/server/tasks/main.yml
+++ b/tests/integration/targets/server/tasks/main.yml
@@ -9,3 +9,6 @@
     - import_role:
         name: common
         tasks_from: cleanup_server_groups
+    - import_role:
+        name: common
+        tasks_from: cleanup_networks


### PR DESCRIPTION
With the addition of the interface parameter the server integration
tests now create networks. These have not been cleaned up because the
network cleanup tasks where missing.