### PR TITLE
Remove "plugin_type" documentation key

### DIFF
--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -9,7 +9,6 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 name: inventory
-plugin_type: inventory
 author:
   - Gaudenz Steinlin (@gaudenz)
 short_description: cloudscale.ch inventory source


### PR DESCRIPTION
This key is no longer allowed in Ansible.

See https://github.com/ansible/ansible/issues/71795#issuecomment-696788179