### PR TITLE
Trigger "Publish release" action on publication

### DIFF
--- a/.github/workflows/publish-ansible-galaxy.yml
+++ b/.github/workflows/publish-ansible-galaxy.yml
@@ -2,7 +2,7 @@ name: Publish release on Ansible Galaxy
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
This action was trigger on release creation. This fails if a release is first created as a draft and then published in a separate step. The creation of a release draft does not (and should not) trigger the "created" event.

We actually want to publish the release on Ansible Galaxy when it's published on Github.