### PR TITLE
Bump minimum Ansible version and improve testing

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,8 +9,10 @@ on:
       - "test/**"
 jobs:
   integration-test:
-    name: Integration test using Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    name: >-
+      Integration test on ansible-core ${{ matrix.ansible }}
+      using Python ${{ matrix.python }}
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ansible_collections/cloudscale_ch/cloud
@@ -19,24 +21,32 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.14
-        python:
-          - 3.10
+          - 2.13
+          - 2.14
+          - 2.15
+        include:
+          - ansible: 2.13
+            python: 3.8
+          - ansible: 2.14
+            python: 3.9
+          - ansible: 2.15
+            python: 3.9
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           path: ansible_collections/cloudscale_ch/cloud
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install ansible and collection dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible
+          # Install the latest ansible-core patchlevel version
+          pip install 'ansible-core~=${{ matrix.ansible }}.0'
           pip install -r tests/requirements.txt
 
       - name: Build and install collection
@@ -64,6 +74,7 @@ jobs:
           ansible-test
           integration
           --docker
+          --python ${{ matrix.python }}
           -v
           --diff
           --color
@@ -98,7 +109,7 @@ jobs:
           email['FROM'] = 'noreply@github.com'
           email['Subject'] = 'Ansible Cloud Module Integration Test Failure'
           email.set_content("""
-          Integration tests using Python ${{ matrix.python-version }} failed:
+          Integration tests using ansible-core ${{ matrix.ansible }} on Python ${{ matrix.python }} failed:
           https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           """)
 

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -13,14 +13,11 @@ jobs:
     strategy:
       matrix:
         ansible:
-        - stable-2.9
-        - stable-2.10
-        - stable-2.11
-        - stable-2.12
         - stable-2.13
         - stable-2.14
+        - stable-2.15
         - devel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.13.0'
 action_groups:
   cloudscale:
   - floating_ip


### PR DESCRIPTION
Bump the minimum version of ansible-core to 2.13.0 and improve integration testing so that all supported and released Ansible versions are tested.