### PR TITLE
Fix failing load balancer tests

### DIFF
--- a/tests/integration/targets/load_balancer_listener/tasks/failures.yml
+++ b/tests/integration/targets/load_balancer_listener/tasks/failures.yml
@@ -20,7 +20,7 @@
   assert:
     that:
       - load_balancer_listener is failed
-      - '"Not found" in load_balancer_listener.fetch_url_info.body'
+      - '"does not exist" in load_balancer_listener.fetch_url_info.body'
 
 - name: Fail create a load balancer listener with non-existing protocol
   cloudscale_ch.cloud.load_balancer_listener:

--- a/tests/integration/targets/load_balancer_pool/tasks/failures.yml
+++ b/tests/integration/targets/load_balancer_pool/tasks/failures.yml
@@ -20,7 +20,7 @@
   assert:
     that:
       - load_balancer_pool is failed
-      - '"Not found" in load_balancer_pool.fetch_url_info.body'
+      - '"does not exist" in load_balancer_pool.fetch_url_info.body'
 
 - name: Fail create a load balancer pool with non-existing algorithm
   cloudscale_ch.cloud.load_balancer_pool:


### PR DESCRIPTION
The load balancer tests verifying that a task referencing an inexistent load balancer fails got broken because of a change in the API response.

This fixes the tests to match part the new API response body. It does not match the whole body to reduce the chance of the test breaking again if the API response slightly changes.