### PR TITLE
Change assertions to work with newer Ansible releases

### DIFF
--- a/tests/integration/targets/load_balancer/tasks/tests.yml
+++ b/tests/integration/targets/load_balancer/tasks/tests.yml
@@ -36,10 +36,10 @@
     that:
       - load_balancer is changed
       - load_balancer.status == 'running'
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer.flavor.slug == '{{ cloudscale_test_flavor_lb }}'
-      - load_balancer.vip_addresses[0].subnet.uuid == '{{ snet.uuid }}'
-      - load_balancer.zone.slug == '{{ cloudscale_test_zone }}'
+      - load_balancer.name == cloudscale_resource_prefix + "-test"
+      - load_balancer.flavor.slug == cloudscale_test_flavor_lb
+      - load_balancer.vip_addresses[0].subnet.uuid == snet.uuid
+      - load_balancer.zone.slug == cloudscale_test_zone
       - load_balancer.tags.project == 'ansible-test'
       - load_balancer.tags.stage == 'production'
       - load_balancer.tags.sla == '24-7'
@@ -61,10 +61,10 @@
     that:
       - load_balancer is not changed
       - load_balancer.status == 'running'
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer.flavor.slug == '{{ cloudscale_test_flavor_lb }}'
-      - load_balancer.vip_addresses[0].subnet.uuid == '{{ snet.uuid }}'
-      - load_balancer.zone.slug == '{{ cloudscale_test_zone }}'
+      - load_balancer.name == cloudscale_resource_prefix + "-test"
+      - load_balancer.flavor.slug == cloudscale_test_flavor_lb
+      - load_balancer.vip_addresses[0].subnet.uuid == snet.uuid
+      - load_balancer.zone.slug == cloudscale_test_zone
       - load_balancer.tags.project == 'ansible-test'
       - load_balancer.tags.stage == 'production'
       - load_balancer.tags.sla == '24-7'
@@ -79,9 +79,9 @@
     that:
       - load_balancer_default_flavor is changed
       - load_balancer_default_flavor.status == 'running'
-      - load_balancer_default_flavor.name == '{{ cloudscale_resource_prefix }}-test2'
-      - load_balancer_default_flavor.flavor.slug == '{{ cloudscale_test_flavor_lb }}'
-      - load_balancer_default_flavor.zone.slug == '{{ cloudscale_test_zone }}'
+      - load_balancer_default_flavor.name == cloudscale_resource_prefix + "-test2"
+      - load_balancer_default_flavor.flavor.slug == cloudscale_test_flavor_lb
+      - load_balancer_default_flavor.zone.slug == cloudscale_test_zone
 
 # Get LB facts
 - name: Test get facts of a load balancer by name
@@ -92,7 +92,7 @@
   assert:
     that:
       - load_balancer is not changed
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer.name == cloudscale_resource_prefix + "-test"
 
 # Update running LB
 - name: Test update name and tags of a running load balancer in check mode
@@ -110,7 +110,7 @@
     that:
       - load_balancer is changed
       - load_balancer.status == 'running'
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer.name == cloudscale_resource_prefix + "-test"
 
 - name: Test update name and tags of a running load balancer
   cloudscale_ch.cloud.load_balancer:
@@ -126,8 +126,8 @@
     that:
       - load_balancer is changed
       - load_balancer.status == 'running'
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer.flavor.slug == '{{ cloudscale_test_flavor_lb }}'
+      - load_balancer.name == cloudscale_resource_prefix + "-test-renamed"
+      - load_balancer.flavor.slug == cloudscale_test_flavor_lb
       - load_balancer.tags.project == 'ansible-test'
       - load_balancer.tags.stage == 'staging'
       - load_balancer.tags.sla == '8-5'
@@ -146,8 +146,8 @@
     that:
       - load_balancer is not changed
       - load_balancer.status == 'running'
-      - load_balancer.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer.flavor.slug == '{{ cloudscale_test_flavor_lb }}'
+      - load_balancer.name == cloudscale_resource_prefix + "-test-renamed"
+      - load_balancer.flavor.slug == cloudscale_test_flavor_lb
       - load_balancer.tags.project == 'ansible-test'
       - load_balancer.tags.stage == 'staging'
       - load_balancer.tags.sla == '8-5'

--- a/tests/integration/targets/load_balancer_health_monitor/tasks/tests.yml
+++ b/tests/integration/targets/load_balancer_health_monitor/tasks/tests.yml
@@ -30,7 +30,7 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool_ping.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool_ping.uuid
       - load_balancer_health_monitor.type == 'ping'
       - load_balancer_health_monitor.tags.project == 'ansible-test'
       - load_balancer_health_monitor.tags.stage == 'production'
@@ -50,7 +50,7 @@
     that:
       - load_balancer_health_monitor is not changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool_ping.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool_ping.uuid
       - load_balancer_health_monitor.type == 'ping'
       - load_balancer_health_monitor.tags.project == 'ansible-test'
       - load_balancer_health_monitor.tags.stage == 'production'
@@ -110,11 +110,11 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_health_monitor.delay_s == {{ cloudscale_test_delay_lb_monitor }}
-      - load_balancer_health_monitor.timeout_s == {{ cloudscale_test_timeout_lb_monitor }}
-      - load_balancer_health_monitor.up_threshold == {{ cloudscale_test_up_threshold_lb_monitor }}
-      - load_balancer_health_monitor.down_threshold == {{ cloudscale_test_down_threshold_lb_monitor }}
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_health_monitor.delay_s == cloudscale_test_delay_lb_monitor
+      - load_balancer_health_monitor.timeout_s == cloudscale_test_timeout_lb_monitor
+      - load_balancer_health_monitor.up_threshold == cloudscale_test_up_threshold_lb_monitor
+      - load_balancer_health_monitor.down_threshold == cloudscale_test_down_threshold_lb_monitor
       - load_balancer_health_monitor.type == 'http'
       - '"200" in load_balancer_health_monitor.http.expected_codes'
       - '"202" in load_balancer_health_monitor.http.expected_codes'
@@ -152,11 +152,11 @@
     that:
       - load_balancer_health_monitor is not changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_health_monitor.delay_s == {{ cloudscale_test_delay_lb_monitor }}
-      - load_balancer_health_monitor.timeout_s == {{ cloudscale_test_timeout_lb_monitor }}
-      - load_balancer_health_monitor.up_threshold == {{ cloudscale_test_up_threshold_lb_monitor }}
-      - load_balancer_health_monitor.down_threshold == {{ cloudscale_test_down_threshold_lb_monitor }}
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_health_monitor.delay_s == cloudscale_test_delay_lb_monitor
+      - load_balancer_health_monitor.timeout_s == cloudscale_test_timeout_lb_monitor
+      - load_balancer_health_monitor.up_threshold == cloudscale_test_up_threshold_lb_monitor
+      - load_balancer_health_monitor.down_threshold == cloudscale_test_down_threshold_lb_monitor
       - load_balancer_health_monitor.type == 'http'
       - '"200" in load_balancer_health_monitor.http.expected_codes'
       - '"202" in load_balancer_health_monitor.http.expected_codes'
@@ -196,11 +196,11 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_health_monitor.delay_s == {{ cloudscale_test_delay_lb_monitor }}
-      - load_balancer_health_monitor.timeout_s == {{ cloudscale_test_timeout_lb_monitor }}
-      - load_balancer_health_monitor.up_threshold == {{ cloudscale_test_up_threshold_lb_monitor }}
-      - load_balancer_health_monitor.down_threshold == {{ cloudscale_test_down_threshold_lb_monitor }}
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_health_monitor.delay_s == cloudscale_test_delay_lb_monitor
+      - load_balancer_health_monitor.timeout_s == cloudscale_test_timeout_lb_monitor
+      - load_balancer_health_monitor.up_threshold == cloudscale_test_up_threshold_lb_monitor
+      - load_balancer_health_monitor.down_threshold == cloudscale_test_down_threshold_lb_monitor
 
 - name: Test update timeouts for a load balancer health monitor
   cloudscale_ch.cloud.load_balancer_health_monitor:
@@ -219,7 +219,7 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
       - load_balancer_health_monitor.delay_s == 2
       - load_balancer_health_monitor.timeout_s == 1
       - load_balancer_health_monitor.up_threshold == 2
@@ -252,7 +252,7 @@
     that:
       - load_balancer_health_monitor is not changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
       - load_balancer_health_monitor.delay_s == 2
       - load_balancer_health_monitor.timeout_s == 1
       - load_balancer_health_monitor.up_threshold == 2
@@ -289,7 +289,7 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
       - load_balancer_health_monitor.http.method == 'GET'
 
 - name: Test update HTTP method of a load balancer health monitor
@@ -318,7 +318,7 @@
     that:
       - load_balancer_health_monitor is changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
       - load_balancer_health_monitor.delay_s == 2
       - load_balancer_health_monitor.timeout_s == 1
       - load_balancer_health_monitor.up_threshold == 2
@@ -360,7 +360,7 @@
     that:
       - load_balancer_health_monitor is not changed
       - load_balancer_health_monitor.state == 'present'
-      - load_balancer_health_monitor.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_health_monitor.pool.uuid == load_balancer_pool.uuid
       - load_balancer_health_monitor.delay_s == 2
       - load_balancer_health_monitor.timeout_s == 1
       - load_balancer_health_monitor.up_threshold == 2
@@ -387,7 +387,7 @@
   assert:
     that:
       - load_balancer_health_monitor is changed
-      - load_balancer_health_monitor.uuid == '{{ load_balancer_health_monitor.uuid }}'
+      - load_balancer_health_monitor.uuid == load_balancer_health_monitor.uuid
 
 - name: Test load balancer health monitor deletion by UUID
   cloudscale_ch.cloud.load_balancer_health_monitor:

--- a/tests/integration/targets/load_balancer_listener/tasks/tests.yml
+++ b/tests/integration/targets/load_balancer_listener/tasks/tests.yml
@@ -45,15 +45,15 @@
   assert:
     that:
       - load_balancer_listener is changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_listener.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_listener.protocol == '{{ cloudscale_test_listener_protocol }}'
-      - load_balancer_listener.protocol_port == {{ cloudscale_test_protocol_port }}
-      - "'{{ cloudscale_test_allowed_cidr_v4 }}' in load_balancer_listener.allowed_cidrs"
-      - "'{{ cloudscale_test_allowed_cidr_v6 }}' in load_balancer_listener.allowed_cidrs"
-      - load_balancer_listener.timeout_client_data_ms == {{ cloudscale_test_timeout_client_data_ms }}
-      - load_balancer_listener.timeout_member_connect_ms == {{ cloudscale_test_timeout_member_connect_ms }}
-      - load_balancer_listener.timeout_member_data_ms == {{ cloudscale_test_timeout_member_data_ms }}
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_listener.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_listener.protocol == cloudscale_test_listener_protocol
+      - load_balancer_listener.protocol_port == cloudscale_test_protocol_port
+      - cloudscale_test_allowed_cidr_v4 in load_balancer_listener.allowed_cidrs
+      - cloudscale_test_allowed_cidr_v6 in load_balancer_listener.allowed_cidrs
+      - load_balancer_listener.timeout_client_data_ms == cloudscale_test_timeout_client_data_ms
+      - load_balancer_listener.timeout_member_connect_ms == cloudscale_test_timeout_member_connect_ms
+      - load_balancer_listener.timeout_member_data_ms == cloudscale_test_timeout_member_data_ms
       - load_balancer_listener.tags.project == 'ansible-test'
       - load_balancer_listener.tags.stage == 'production'
       - load_balancer_listener.tags.sla == '24-7'
@@ -79,15 +79,15 @@
   assert:
     that:
       - load_balancer_listener is not changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_listener.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_listener.protocol == '{{ cloudscale_test_listener_protocol }}'
-      - load_balancer_listener.protocol_port == {{ cloudscale_test_protocol_port }}
-      - "'{{ cloudscale_test_allowed_cidr_v4 }}' in load_balancer_listener.allowed_cidrs"
-      - "'{{ cloudscale_test_allowed_cidr_v6 }}' in load_balancer_listener.allowed_cidrs"
-      - load_balancer_listener.timeout_client_data_ms == {{ cloudscale_test_timeout_client_data_ms }}
-      - load_balancer_listener.timeout_member_connect_ms == {{ cloudscale_test_timeout_member_connect_ms }}
-      - load_balancer_listener.timeout_member_data_ms == {{ cloudscale_test_timeout_member_data_ms }}
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_listener.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_listener.protocol == cloudscale_test_listener_protocol
+      - load_balancer_listener.protocol_port == cloudscale_test_protocol_port
+      - cloudscale_test_allowed_cidr_v4 in load_balancer_listener.allowed_cidrs
+      - cloudscale_test_allowed_cidr_v6 in load_balancer_listener.allowed_cidrs
+      - load_balancer_listener.timeout_client_data_ms == cloudscale_test_timeout_client_data_ms
+      - load_balancer_listener.timeout_member_connect_ms == cloudscale_test_timeout_member_connect_ms
+      - load_balancer_listener.timeout_member_data_ms == cloudscale_test_timeout_member_data_ms
       - load_balancer_listener.tags.project == 'ansible-test'
       - load_balancer_listener.tags.stage == 'production'
       - load_balancer_listener.tags.sla == '24-7'
@@ -127,15 +127,15 @@
   assert:
     that:
       - load_balancer_listener is changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_listener.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_listener.protocol == '{{ cloudscale_test_listener_protocol }}'
-      - load_balancer_listener.protocol_port == {{ cloudscale_test_protocol_port }}
-      - "'{{ cloudscale_test_allowed_cidr_v4 }}' in load_balancer_listener.allowed_cidrs"
-      - "'{{ cloudscale_test_allowed_cidr_v6 }}' in load_balancer_listener.allowed_cidrs"
-      - load_balancer_listener.timeout_client_data_ms == {{ cloudscale_test_timeout_client_data_ms }}
-      - load_balancer_listener.timeout_member_connect_ms == {{ cloudscale_test_timeout_member_connect_ms }}
-      - load_balancer_listener.timeout_member_data_ms == {{ cloudscale_test_timeout_member_data_ms }}
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_listener.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_listener.protocol == cloudscale_test_listener_protocol
+      - load_balancer_listener.protocol_port == cloudscale_test_protocol_port
+      - cloudscale_test_allowed_cidr_v4 in load_balancer_listener.allowed_cidrs
+      - cloudscale_test_allowed_cidr_v6 in load_balancer_listener.allowed_cidrs
+      - load_balancer_listener.timeout_client_data_ms == cloudscale_test_timeout_client_data_ms
+      - load_balancer_listener.timeout_member_connect_ms == cloudscale_test_timeout_member_connect_ms
+      - load_balancer_listener.timeout_member_data_ms == cloudscale_test_timeout_member_data_ms
       - load_balancer_listener.tags.project == 'ansible-test'
       - load_balancer_listener.tags.stage == 'production'
       - load_balancer_listener.tags.sla == '24-7'
@@ -162,13 +162,13 @@
   assert:
     that:
       - load_balancer_listener is changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer_listener.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_listener.protocol == '{{ cloudscale_test_listener_protocol }}'
-      - load_balancer_listener.protocol_port == {{ cloudscale_test_protocol_port }}
-      - "'{{ cloudscale_test_allowed_cidr_v4 }}' not in load_balancer_listener.allowed_cidrs"
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test-renamed"
+      - load_balancer_listener.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_listener.protocol == cloudscale_test_listener_protocol
+      - load_balancer_listener.protocol_port == cloudscale_test_protocol_port
+      - cloudscale_test_allowed_cidr_v4 not in load_balancer_listener.allowed_cidrs
       - "'192.168.1.0/24' in load_balancer_listener.allowed_cidrs"
-      - "'{{ cloudscale_test_allowed_cidr_v6 }}' in load_balancer_listener.allowed_cidrs"
+      - cloudscale_test_allowed_cidr_v6 in load_balancer_listener.allowed_cidrs
       - load_balancer_listener.timeout_client_data_ms == 40001
       - load_balancer_listener.timeout_member_connect_ms == 4001
       - load_balancer_listener.timeout_member_data_ms == 40001
@@ -198,13 +198,13 @@
   assert:
     that:
       - load_balancer_listener is not changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer_listener.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_listener.protocol == '{{ cloudscale_test_listener_protocol }}'
-      - load_balancer_listener.protocol_port == {{ cloudscale_test_protocol_port }}
-      - "'{{ cloudscale_test_allowed_cidr_v4 }}' not in load_balancer_listener.allowed_cidrs"
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test-renamed"
+      - load_balancer_listener.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_listener.protocol == cloudscale_test_listener_protocol
+      - load_balancer_listener.protocol_port == cloudscale_test_protocol_port
+      - cloudscale_test_allowed_cidr_v4 not in load_balancer_listener.allowed_cidrs
       - "'192.168.1.0/24' in load_balancer_listener.allowed_cidrs"
-      - "'{{ cloudscale_test_allowed_cidr_v6 }}' in load_balancer_listener.allowed_cidrs"
+      - cloudscale_test_allowed_cidr_v6 in load_balancer_listener.allowed_cidrs
       - load_balancer_listener.timeout_client_data_ms == 40001
       - load_balancer_listener.timeout_member_connect_ms == 4001
       - load_balancer_listener.timeout_member_data_ms == 40001
@@ -223,7 +223,7 @@
   assert:
     that:
       - load_balancer_listener is changed
-      - load_balancer_listener.name == '{{ cloudscale_resource_prefix }}-test-renamed'
+      - load_balancer_listener.name == cloudscale_resource_prefix + "-test-renamed"
 
 - name: Test load balancer listener deletion by name
   cloudscale_ch.cloud.load_balancer_listener:

--- a/tests/integration/targets/load_balancer_pool/tasks/tests.yml
+++ b/tests/integration/targets/load_balancer_pool/tasks/tests.yml
@@ -33,8 +33,8 @@
   assert:
     that:
       - load_balancer_pool is changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool.load_balancer.uuid == '{{ load_balancer.uuid }}'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool.load_balancer.uuid == load_balancer.uuid
       - load_balancer_pool.tags.project == 'ansible-test'
       - load_balancer_pool.tags.stage == 'production'
       - load_balancer_pool.tags.sla == '24-7'
@@ -54,8 +54,8 @@
   assert:
     that:
       - load_balancer_pool is not changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool.load_balancer.uuid == '{{ load_balancer.uuid }}'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool.load_balancer.uuid == load_balancer.uuid
       - load_balancer_pool.tags.project == 'ansible-test'
       - load_balancer_pool.tags.stage == 'production'
       - load_balancer_pool.tags.sla == '24-7'
@@ -69,7 +69,7 @@
   assert:
     that:
       - load_balancer_pool is not changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test"
 
 # Update LB Pool
 - name: Test update name and tags of a running load balancer pool in check mode
@@ -86,7 +86,7 @@
   assert:
     that:
       - load_balancer_pool is changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test"
 
 - name: Test update name and tags of a running load balancer pool
   cloudscale_ch.cloud.load_balancer_pool:
@@ -101,7 +101,7 @@
   assert:
     that:
       - load_balancer_pool is changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test-renamed'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test-renamed"
       - load_balancer_pool.tags.project == 'ansible-test'
       - load_balancer_pool.tags.stage == 'staging'
       - load_balancer_pool.tags.sla == '8-5'
@@ -119,7 +119,7 @@
   assert:
     that:
       - load_balancer_pool is not changed
-      - load_balancer_pool.name == '{{ cloudscale_resource_prefix }}-test-renamed'
+      - load_balancer_pool.name == cloudscale_resource_prefix + "-test-renamed"
       - load_balancer_pool.tags.project == 'ansible-test'
       - load_balancer_pool.tags.stage == 'staging'
       - load_balancer_pool.tags.sla == '8-5'

--- a/tests/integration/targets/load_balancer_pool_member/tasks/tests.yml
+++ b/tests/integration/targets/load_balancer_pool_member/tasks/tests.yml
@@ -39,11 +39,11 @@
   assert:
     that:
       - load_balancer_pool_member is changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_pool_member.enabled == {{ cloudscale_test_enabled_lb_member }}
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_pool_member.enabled == cloudscale_test_enabled_lb_member
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -66,11 +66,11 @@
   assert:
     that:
       - load_balancer_pool_member is not changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_pool_member.enabled == {{ cloudscale_test_enabled_lb_member }}
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_pool_member.enabled == cloudscale_test_enabled_lb_member
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -85,7 +85,7 @@
   assert:
     that:
       - load_balancer_pool_member is not changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
 
 - name: Test get facts of a load balancer pool member by UUID
   cloudscale_ch.cloud.load_balancer_pool_member:
@@ -96,7 +96,7 @@
   assert:
     that:
       - load_balancer_pool_member is not changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
 
 # Update LB pool member
 - name: Test update disable a load balancer pool member in check mode
@@ -118,11 +118,11 @@
   assert:
     that:
       - load_balancer_pool_member is changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
-      - load_balancer_pool_member.enabled == {{ cloudscale_test_enabled_lb_member }}
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
+      - load_balancer_pool_member.enabled == cloudscale_test_enabled_lb_member
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -145,11 +145,11 @@
   assert:
     that:
       - load_balancer_pool_member is changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
       - load_balancer_pool_member.enabled == false
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -172,11 +172,11 @@
   assert:
     that:
       - load_balancer_pool_member is not changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
       - load_balancer_pool_member.enabled == false
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -202,11 +202,11 @@
   assert:
     that:
       - load_balancer_pool_member is changed
-      - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_pool_member.name == cloudscale_resource_prefix + "-test"
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
       - load_balancer_pool_member.enabled == false
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -231,10 +231,10 @@
     that:
       - load_balancer_pool_member is changed
       - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
       - load_balancer_pool_member.enabled == false
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'
@@ -259,10 +259,10 @@
     that:
       - load_balancer_pool_member is not changed
       - load_balancer_pool_member.name == '{{ cloudscale_resource_prefix }}-test-renamed'
-      - load_balancer_pool_member.pool.uuid == '{{ load_balancer_pool.uuid }}'
+      - load_balancer_pool_member.pool.uuid == load_balancer_pool.uuid
       - load_balancer_pool_member.enabled == false
-      - load_balancer_pool_member.protocol_port == {{ cloudscale_test_protocol_port_lb_member }}
-      - load_balancer_pool_member.monitor_port == {{ cloudscale_test_monitor_port_lb_member }}
+      - load_balancer_pool_member.protocol_port == cloudscale_test_protocol_port_lb_member
+      - load_balancer_pool_member.monitor_port == cloudscale_test_monitor_port_lb_member
       - load_balancer_pool_member.tags.project == 'ansible-test'
       - load_balancer_pool_member.tags.stage == 'production'
       - load_balancer_pool_member.tags.sla == '24-7'


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_9.html#playbook

With these changes, the tests all pass again: https://github.com/cloudscale-ch/ansible-collection-cloudscale/actions/runs/7640623493