### PR TITLE
Use a more exact integration test name

### DIFF
--- a/.github/workflows/ansible-collection-integration-tests.yml
+++ b/.github/workflows/ansible-collection-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Collection Integration tests
+name: Ansible Collection Integration Tests
 
 on:
   schedule:


### PR DESCRIPTION
This enables the internal test monitoring to show more descriptive names.