### PR TITLE
Fix sanity tests, ansible-core >= py311

### DIFF
--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         ansible:
-        - stable-2.13
-        - stable-2.14
         - stable-2.15
+        - stable-2.16
+        - stable-2.17
         - devel
     runs-on: ubuntu-22.04
     steps:
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install ansible-base (${{ matrix.ansible }})
       run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check


### PR DESCRIPTION
ERROR: Package 'ansible-core' requires a different Python: 3.10.14 not in '>=3.11'