### PR TITLE
Add token validation

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -44,6 +44,9 @@ class AnsibleCloudscaleApi(object):
         if not self._api_url.endswith('/'):
             self._api_url = self._api_url + '/'
 
+        if not module.params['api_token'].isalnum():
+            self._module.fail_json(msg='Invalid API Token')
+
         self._auth_header = {'Authorization': 'Bearer %s' % module.params['api_token']}
 
     def _get(self, api_call):


### PR DESCRIPTION
If the api_token contains newline characters, the following error, with the token in plaintext, is displayed:

```
failed: [server.example.org -> localhost] (item={'name': 'group1', 'zone': 'rma1'}) => changed=false 
  ansible_loop_var: item
  item:
    name: group1
    zone: rma1
  msg: Invalid header value b'Bearer <token_redacted>\n'
  status: -1
  url: https://api.cloudscale.ch/v1/server-groups
```
[cloudscale_argument_spec()](https://github.com/cloudscale-ch/ansible-collection-cloudscale/blob/f6ffeda00dd4205a9e7890902147073638c22b2c/plugins/module_utils/api.py#L27) defines this parameter as `no_log=True`.
Our fix validates that the token is an alphanumeric string. If not, an error message is returned, using `module.fail_json` which results in the following error being logged:
```
failed: [server.example.org -> localhost] (item={'name': 'group1', 'zone': 'rma1'}) => changed=false 
  ansible_loop_var: item
  item:
    name: group1
    zone: rma1
  msg: Invalid API Token
```

