### PR TITLE
Remove error message if a volume snapshot is attached to a server

### DIFF
--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -225,8 +225,6 @@ class AnsibleCloudscaleVolume(AnsibleCloudscaleBase):
 
     def revert(self):
         resource = self.query()
-        if len(resource['servers']) > 0:
-            self._module.fail_json(msg='Cannot revert a volume that is attached to server')
         revert_url = resource['href'] + '/revert'
         revert_param = {'snapshot': self._module.params['revert']}
         revert = self._post(revert_url, revert_param)

--- a/tests/integration/targets/volume/tasks/failures.yml
+++ b/tests/integration/targets/volume/tasks/failures.yml
@@ -36,3 +36,14 @@
     that:
       - vol is failed
       - vol.msg.startswith("The resource with UUID 'ea3b39a3-77a8-4d0b-881d-0bb00a1e7f48' was not found")
+
+- name: Fail revert root volume running
+  cloudscale_ch.cloud.volume:
+    uuid: '{{ server.volumes.0.uuid }}'
+    revert: '{{ root_volume_snapshot.uuid }}'
+  register: revert
+  ignore_errors: True
+- name: 'VERIFY: Fail revert root volume running'
+  assert:
+    that:
+      - revert is failed

--- a/tests/integration/targets/volume/tasks/failures.yml
+++ b/tests/integration/targets/volume/tasks/failures.yml
@@ -37,13 +37,13 @@
       - vol is failed
       - vol.msg.startswith("The resource with UUID 'ea3b39a3-77a8-4d0b-881d-0bb00a1e7f48' was not found")
 
-- name: Fail revert root volume running
+- name: Fail revert a root volume on a running server
   cloudscale_ch.cloud.volume:
     uuid: '{{ server.volumes.0.uuid }}'
     revert: '{{ root_volume_snapshot.uuid }}'
-  register: revert
+  register: revert_root_volume
   ignore_errors: True
-- name: 'VERIFY: Fail revert root volume running'
+- name: 'VERIFY: Fail revert a root volume on a running server'
   assert:
     that:
-      - revert is failed
+      - revert_root_volume is failed

--- a/tests/integration/targets/volume/tasks/main.yml
+++ b/tests/integration/targets/volume/tasks/main.yml
@@ -7,10 +7,10 @@
   always:
     - import_role:
         name: common
-        tasks_from: cleanup_servers
+        tasks_from: cleanup_volume_snapshots
     - import_role:
         name: common
-        tasks_from: cleanup_volume_snapshots
+        tasks_from: cleanup_servers
     - import_role:
         name: common
         tasks_from: cleanup_volumes

--- a/tests/integration/targets/volume/tasks/setup.yml
+++ b/tests/integration/targets/volume/tasks/setup.yml
@@ -8,3 +8,9 @@
     ssh_keys:
       - '{{ cloudscale_test_ssh_key }}'
   register: server
+
+- name: Create snapshot of root volume
+  cloudscale_ch.cloud.volume_snapshot:
+    name: '{{ cloudscale_resource_prefix }}-test-root-volume-snapshot'
+    source_volume: '{{ server.volumes.0.uuid }}'
+  register: root_volume_snapshot

--- a/tests/integration/targets/volume/tasks/tests.yml
+++ b/tests/integration/targets/volume/tasks/tests.yml
@@ -33,8 +33,8 @@
       - vol is successful
       - vol is changed
       - vol.size_gb == 50
-      - vol.name == '{{ cloudscale_resource_prefix }}-vol'
-      - vol.zone.slug == '{{ cloudscale_test_zone }}'
+      - vol.name == cloudscale_resource_prefix + '-vol'
+      - vol.zone.slug == cloudscale_test_zone
       - vol.tags.project == 'ansible-test'
       - vol.tags.stage == 'production'
       - vol.tags.sla == '24-7'
@@ -55,8 +55,8 @@
       - vol is successful
       - vol is not changed
       - vol.size_gb == 50
-      - vol.name == '{{ cloudscale_resource_prefix }}-vol'
-      - vol.zone.slug == '{{ cloudscale_test_zone }}'
+      - vol.name == cloudscale_resource_prefix + '-vol'
+      - vol.zone.slug == cloudscale_test_zone
       - vol.tags.project == 'ansible-test'
       - vol.tags.stage == 'production'
       - vol.tags.sla == '24-7'
@@ -185,7 +185,7 @@
       - deleted is changed
       - deleted.state == 'present'
       - deleted.uuid == vol.uuid
-      - deleted.name == '{{ cloudscale_resource_prefix }}-vol'
+      - deleted.name == cloudscale_resource_prefix + '-vol'
 
 - name: Delete attached volume by UUID
   cloudscale_ch.cloud.volume:
@@ -199,7 +199,7 @@
       - deleted is changed
       - deleted.state == 'absent'
       - deleted.uuid == vol.uuid
-      - deleted.name == '{{ cloudscale_resource_prefix }}-vol'
+      - deleted.name == cloudscale_resource_prefix + '-vol'
 
 - name: Delete attached volume by UUID idempotence
   cloudscale_ch.cloud.volume:

--- a/tests/integration/targets/volume/tasks/tests.yml
+++ b/tests/integration/targets/volume/tasks/tests.yml
@@ -293,19 +293,19 @@
       - bulk is not changed
       - bulk.state == 'absent'
 
-- name: Stop server
+- name: Stop test server
   cloudscale_ch.cloud.server:
     uuid: '{{ server.uuid }}'
     state: stopped
-  register: stop_server
+  register: server_stopped
 
-- name: Revert root volume stopped
+- name: Revert root volume of stopped server
   cloudscale_ch.cloud.volume:
     uuid: '{{ server.volumes.0.uuid }}'
     revert: '{{ root_volume_snapshot.uuid }}'
-  register: revert
-- name: 'VERIFY: Revert volume to snapshot'
+  register: revert_root_volume
+- name: 'VERIFY: Revert root volume of stopped server'
   assert:
     that:
-      - revert is successful
-      - revert is changed
+      - revert_root_volume is successful
+      - revert_root_volume is changed

--- a/tests/integration/targets/volume/tasks/tests.yml
+++ b/tests/integration/targets/volume/tasks/tests.yml
@@ -292,3 +292,20 @@
       - bulk is successful
       - bulk is not changed
       - bulk.state == 'absent'
+
+- name: Stop server
+  cloudscale_ch.cloud.server:
+    uuid: '{{ server.uuid }}'
+    state: stopped
+  register: stop_server
+
+- name: Revert root volume stopped
+  cloudscale_ch.cloud.volume:
+    uuid: '{{ server.volumes.0.uuid }}'
+    revert: '{{ root_volume_snapshot.uuid }}'
+  register: revert
+- name: 'VERIFY: Revert volume to snapshot'
+  assert:
+    that:
+      - revert is successful
+      - revert is changed


### PR DESCRIPTION
This allows to revert a root volume attached to a stopped server.